### PR TITLE
Fix: Remove duplicate script tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,10 +167,3 @@
   <script src="app.js"></script>
 </body>
 </html>
-
-  <script src="script.js"></script>
-  <script src="app.js"></script>       <!-- UI code uses TDD code -->
-
-  
-</body>
-</html>


### PR DESCRIPTION
**Fixes:** #25 
Closes #25 

**Type:** Bug Fix  
**Priority:** High
**Severity:** Medium

---

## Bug Description
The application was completely broken due to duplicate `<script>` tags in `index.html`, causing JavaScript files to load twice and throw "Identifier already declared" errors.

## Root Cause
The HTML file contained:
- First set of script tags (correct)
- **Duplicate** second set of script tags (incorrect)
- **Duplicate** `</body>` and `</html>` closing tags

This caused both `script.js` and `app.js` to execute twice, redeclaring all constants:
```
const quizQuestions = [...] // First load ✓
const quizQuestions = [...] // Second load ✗ ERROR!
```

## Changes Made

### **File Modified:** `index.html`

**Lines Removed:**
- Duplicate `<script src="script.js"></script>` tag
- Duplicate `<script src="app.js"></script>` tag
- Duplicate `</body>` closing tag
- Duplicate `</html>` closing tag

## Impact of Bug

### **Before Fix (Broken):**
- ❌ Console errors on page load
- ❌ Score calculation broken

### **After Fix (Working):**
- ✅ No console errors
- ✅ Quiz fully functional
- ✅ Score displays correctly
- ✅ All features working